### PR TITLE
More efficient optimal observable module

### DIFF
--- a/external_chi2/optimal_observables/interface_oos.py
+++ b/external_chi2/optimal_observables/interface_oos.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pathlib
+import jax.numpy as jnp
 
 current_file_path = pathlib.Path(__file__).resolve().parent
 
@@ -27,16 +28,18 @@ class OptimalWW:
             '{collider}_ww_semilep_365': 'invcov_{collider}_ww_semilep_365.dat'
         }
 
-        self.invcovs = [np.loadtxt(current_file_path / path.format(collider=collider)) for path in self.datasets.values()]
+        incovs_reordered = []
+        for path in self.datasets.values():
+            invcov = np.loadtxt(current_file_path / path.format(collider=collider))
+            temp = self.project.T @ invcov @ self.project
+            incovs_reordered.append(temp)
+        self.incovs_reordered = jnp.sum(jnp.array(incovs_reordered), axis=0)
 
         self.n_dat = len(oo_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
-        chi2_value = 0
-        for invcov in self.invcovs:
-            chi2_value += np.linalg.multi_dot(
-                [coefficient_values, self.project.T, invcov, self.project, coefficient_values])
+        chi2_value = coefficient_values @ self.incovs_reordered @ coefficient_values
 
         return chi2_value
 
@@ -56,17 +59,19 @@ class Optimaltt:
             '{collider}_tt_365': 'invcov_{collider}_tt_365GeV.dat'
         }
 
-        self.invcovs = [np.loadtxt(current_file_path / path.format(collider=collider)) for path in
-                        self.datasets.values()]
+        incovs_reordered = []
+        for path in self.datasets.values():
+            invcov = np.loadtxt(current_file_path / path.format(collider=collider))
+            temp = self.project.T @ invcov @ self.project
+            incovs_reordered.append(temp)
+        self.incovs_reordered = jnp.sum(jnp.array(incovs_reordered), axis=0)
 
         self.n_dat = len(oo_tt_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
-        chi2_value = 0
-        for invcov in self.datasets.values():
-            chi2_value += np.linalg.multi_dot(
-                [coefficient_values, self.project.T, invcov, self.project, coefficient_values])
+        chi2_value = coefficient_values @ self.incovs_reordered @ coefficient_values
+
         return chi2_value
 
 

--- a/external_chi2/optimal_observables/interface_oos.py
+++ b/external_chi2/optimal_observables/interface_oos.py
@@ -27,13 +27,14 @@ class OptimalWW:
             '{collider}_ww_semilep_365': 'invcov_{collider}_ww_semilep_365.dat'
         }
 
+        self.invcovs = [np.loadtxt(current_file_path / path.format(collider=collider)) for path in self.datasets.values()]
+
         self.n_dat = len(oo_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
         chi2_value = 0
-        for invcov_path in self.datasets.values():
-            invcov = np.loadtxt(current_file_path / invcov_path.format(collider=collider))
+        for invcov in self.invcovs:
             chi2_value += np.linalg.multi_dot(
                 [coefficient_values, self.project.T, invcov, self.project, coefficient_values])
 
@@ -54,13 +55,16 @@ class Optimaltt:
         self.datasets = {
             '{collider}_tt_365': 'invcov_{collider}_tt_365GeV.dat'
         }
+
+        self.invcovs = [np.loadtxt(current_file_path / path.format(collider=collider)) for path in
+                        self.datasets.values()]
+
         self.n_dat = len(oo_tt_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
         chi2_value = 0
-        for invcov_path in self.datasets.values():
-            invcov = np.loadtxt(current_file_path / invcov_path.format(collider=collider))
+        for invcov in self.datasets.values():
             chi2_value += np.linalg.multi_dot(
                 [coefficient_values, self.project.T, invcov, self.project, coefficient_values])
         return chi2_value

--- a/external_chi2/optimal_observables/interface_oos.py
+++ b/external_chi2/optimal_observables/interface_oos.py
@@ -31,15 +31,15 @@ class OptimalWW:
         incovs_reordered = []
         for path in self.datasets.values():
             invcov = np.loadtxt(current_file_path / path.format(collider=collider))
-            temp = self.project.T @ invcov @ self.project
+            temp = jnp.einsum("i, ij, j", self.project.T, invcov, self.project)
             incovs_reordered.append(temp)
-        self.incovs_reordered = jnp.sum(jnp.array(incovs_reordered), axis=0)
+        self.incov_tot = jnp.sum(jnp.array(incovs_reordered), axis=0)
 
         self.n_dat = len(oo_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
-        chi2_value = coefficient_values @ self.incovs_reordered @ coefficient_values
+        chi2_value = jnp.einsum("i, ij, j", coefficient_values, self.incov_tot, coefficient_values)
 
         return chi2_value
 
@@ -62,15 +62,15 @@ class Optimaltt:
         incovs_reordered = []
         for path in self.datasets.values():
             invcov = np.loadtxt(current_file_path / path.format(collider=collider))
-            temp = self.project.T @ invcov @ self.project
+            temp = jnp.einsum("i, ij, j", self.project.T, invcov, self.project)
             incovs_reordered.append(temp)
-        self.incovs_reordered = jnp.sum(jnp.array(incovs_reordered), axis=0)
+        self.incov_tot = jnp.sum(jnp.array(incovs_reordered), axis=0)
 
         self.n_dat = len(oo_tt_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
-        chi2_value = coefficient_values @ self.incovs_reordered @ coefficient_values
+        chi2_value = jnp.einsum("i, ij, j", coefficient_values, self.incov_tot, coefficient_values)
 
         return chi2_value
 

--- a/external_chi2/optimal_observables/interface_oos_240.py
+++ b/external_chi2/optimal_observables/interface_oos_240.py
@@ -25,13 +25,15 @@ class OptimalWW:
 
         }
 
+        self.invcovs = [np.loadtxt(current_file_path / path.format(collider=collider)) for path in
+                        self.datasets.values()]
+
         self.n_dat = len(oo_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
         chi2_value = 0
-        for invcov_path in self.datasets.values():
-            invcov = np.loadtxt(current_file_path / invcov_path.format(collider=collider))
+        for invcov in self.invcovs:
             chi2_value += np.linalg.multi_dot(
                 [coefficient_values, self.project.T, invcov, self.project, coefficient_values])
 

--- a/external_chi2/optimal_observables/interface_oos_240.py
+++ b/external_chi2/optimal_observables/interface_oos_240.py
@@ -29,16 +29,15 @@ class OptimalWW:
         incovs_reordered = []
         for path in self.datasets.values():
             invcov = np.loadtxt(current_file_path / path.format(collider=collider))
-            temp = self.project.T @ invcov @ self.project
+            temp = jnp.einsum("i, ij, j", self.project.T, invcov, self.project)
             incovs_reordered.append(temp)
-
-        self.incovs_reordered = jnp.sum(jnp.array(incovs_reordered), axis=0)
+        self.incov_tot = jnp.sum(jnp.array(incovs_reordered), axis=0)
 
         self.n_dat = len(oo_wc_basis)
 
     def compute_chi2(self, coefficient_values):
 
-        chi2_value = coefficient_values @ self.incovs_reordered @ coefficient_values
+        chi2_value = jnp.einsum("i, ij, j", coefficient_values, self.incov_tot, coefficient_values)
 
         return chi2_value
 


### PR DESCRIPTION
This PR makes the optimal observables more efficient to run. It moves the reading of the inverse covariance files to the constructor such that this is no longer repeatedly happens during optimisation. 

I reproduced the benchmark results that we used to test JAX:

![coefficient_histo](https://github.com/LHCfitNikhef/smefit_database/assets/54140851/5dc268bf-3bd3-41a9-b651-d5b3b22e6c64)

New time: 15.448 minutes (single core, single precision)
Old time: 15.770 minutes (single core, single precision)

Mild speed up, but worth including anyhow. 
