### PR TITLE
Z pole metadata

### DIFF
--- a/commondata/CEPC_Zdata.yaml
+++ b/commondata/CEPC_Zdata.yaml
@@ -1,6 +1,6 @@
 dataset_name: CEPC_Zdata
 units: pb,GeV
-description: EWPOs
+description: The order corresponds to the observables GammaZ, SigmaHad, Re, Rmu, Rtau, Ae, Amu, Atau, Rb, Rc, Ab, Ac
 luminosity: 100000
 num_data: 12
 num_sys: 12

--- a/commondata/FCCee_Zdata.yaml
+++ b/commondata/FCCee_Zdata.yaml
@@ -1,6 +1,6 @@
 dataset_name: FCCee_EWPOs
 units: pb/GeV
-description: EWPOs
+description: The order corresponds to the observables GammaZ, SigmaHad, Re, Rmu, Rtau, Ae, Amu, Atau, Rb, Rc, Ab, Ac
 luminosity: 300000
 num_data: 12
 num_sys: 12

--- a/commondata/LEP1_EWPOs_2006.yaml
+++ b/commondata/LEP1_EWPOs_2006.yaml
@@ -1,6 +1,8 @@
 dataset_name: LEP1_EWPOs_2006
 num_data: 19
 num_sys: 19
+description: The order corresponds to the observables GammaZ, SigmaHad, Re, Rmu, Rtau, AFBe, AFBmu, AFBtau, AeSLD, 
+  AmuSLD, AtauSLD, AtauPT, AePT, Rb, Rc, AFBb, AFBc, Ab, Ac
 data_central:
   - 2.4952
   - 41541.0

--- a/commondata/LEP1_EWPOs_2006.yaml
+++ b/commondata/LEP1_EWPOs_2006.yaml
@@ -1,8 +1,7 @@
 dataset_name: LEP1_EWPOs_2006
 num_data: 19
 num_sys: 19
-description: The order corresponds to the observables GammaZ, SigmaHad, Re, Rmu, Rtau, AFBe, AFBmu, AFBtau, AeSLD, 
-  AmuSLD, AtauSLD, AtauPT, AePT, Rb, Rc, AFBb, AFBc, Ab, Ac
+description: The order corresponds to the observables GammaZ, SigmaHad, Re, Rmu, Rtau, AFBe, AFBmu, AFBtau, AeSLD, AmuSLD, AtauSLD, AtauPT, AePT, Rb, Rc, AFBb, AFBc, Ab, Ac
 data_central:
   - 2.4952
   - 41541.0


### PR DESCRIPTION
This PR adds the order of the Z pole observables as metadata. 

For @ecelada, could you maybe add this to the FCC-ee Z pole data as well? Thanks! 