### PR TITLE
reinstating runcard script

### DIFF
--- a/runcards/A_LHC_NLO_LIN_GLOB.yaml
+++ b/runcards/A_LHC_NLO_LIN_GLOB.yaml
@@ -68,7 +68,6 @@ datasets:
   - {name: CMS_tZ_13TeV_inc, order: NLO_QCD}
   - {name: CMS_tZ_13TeV_pTt, order: NLO_QCD}
   - {name: CMS_t_sch_8TeV, order: NLO_QCD}
-  - {name: CMS_t_tch_13TeV_2016_diff_Yt, order: NLO_QCD}
   - {name: CMS_t_tch_13TeV_2019_diff_Yt, order: NLO_QCD}
   - {name: CMS_t_tch_13TeV_inc, order: NLO_QCD}
   - {name: CMS_t_tch_8TeV_diff_Yt, order: NLO_QCD}
@@ -114,11 +113,6 @@ coefficients:
   OtG: {'min': -1.0, 'max': 1.0}
   Otp: {'min': -8.0, 'max': 8.0}
   OtZ: {'min': -2, 'max': 2}
-  OQQ1: {'min': -10, 'max': 10.0}
-  OQQ8: {'min': -20.0, 'max': 20.0}
-  OQt1: {'min': -5.0, 'max': 5.0}
-  OQt8: {'min': -10.0, 'max': 10.0}
-  Ott1: {'min': -2.0, 'max': 2.0}
   O81qq: {'min': -1, 'max': 1}
   O11qq: {'min': -1, 'max': 1}
   O83qq: {'min': -1, 'max': 1}
@@ -161,4 +155,4 @@ coefficients:
   Oll1111: {'constrain': [{'Oll': 1}], 'min': -1.5, 'max': 1.0}
   ## DIBOSON COEFFICIENTS ##
   OWWW: {'min': -0.5, 'max': 0.5}
-rot_to_fit_basis: null
+

--- a/runcards/A_LHC_NLO_LIN_IND.yaml
+++ b/runcards/A_LHC_NLO_LIN_IND.yaml
@@ -70,7 +70,6 @@ datasets:
   - {name: CMS_tZ_13TeV_inc, order: NLO_QCD}
   - {name: CMS_tZ_13TeV_pTt, order: NLO_QCD}
   - {name: CMS_t_sch_8TeV, order: NLO_QCD}
-  - {name: CMS_t_tch_13TeV_2016_diff_Yt, order: NLO_QCD}
   - {name: CMS_t_tch_13TeV_2019_diff_Yt, order: NLO_QCD}
   - {name: CMS_t_tch_13TeV_inc, order: NLO_QCD}
   - {name: CMS_t_tch_8TeV_diff_Yt, order: NLO_QCD}

--- a/runcards/NS_LHC_NLO_QUAD_GLOB.yaml
+++ b/runcards/NS_LHC_NLO_QUAD_GLOB.yaml
@@ -72,7 +72,6 @@ datasets:
   - {name: CMS_tZ_13TeV_inc, order: NLO_QCD}
   - {name: CMS_tZ_13TeV_pTt, order: NLO_QCD}
   - {name: CMS_t_sch_8TeV, order: NLO_QCD}
-  - {name: CMS_t_tch_13TeV_2016_diff_Yt, order: NLO_QCD}
   - {name: CMS_t_tch_13TeV_2019_diff_Yt, order: NLO_QCD}
   - {name: CMS_t_tch_13TeV_inc, order: NLO_QCD}
   - {name: CMS_t_tch_8TeV_diff_Yt, order: NLO_QCD}

--- a/update_runcards_path.py
+++ b/update_runcards_path.py
@@ -1,0 +1,53 @@
+import argparse
+import pathlib
+import os
+
+import yaml
+
+here = pathlib.Path(__file__).parent.absolute()
+
+
+def load_base_runcard(base_runcard_path):
+    with open(base_runcard_path, "r", encoding="utf-8") as f:
+        base_runcard = yaml.safe_load(f)
+    return base_runcard
+
+
+def update_paths(loaded_runcard, destination):
+    # path to common data
+    loaded_runcard["data_path"] = os.path.normpath(
+        here.joinpath("commondata").as_posix()
+    )
+    # path to theory tables, default same as data path
+    loaded_runcard["theory_path"] = os.path.normpath(here.joinpath("theory").as_posix())
+    # absolute path where results are stored
+    loaded_runcard["result_path"] = os.path.normpath(
+        destination.joinpath("results").as_posix()
+    )
+    return loaded_runcard
+
+
+def dump_runcard(card, file_name, destination):
+    with open(destination / f"{file_name}.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(card, f, sort_keys=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Setup smefit runcards updating the paths."
+    )
+    parser.add_argument(
+        "base_runcard", type=pathlib.Path, help="path to base runcards to update"
+    )
+    parser.add_argument(
+        "-d",
+        "--destination",
+        type=pathlib.Path,
+        default=here,
+        help="path to smefit runcards folder",
+    )
+    args = parser.parse_args()
+
+    loaded_runcard = load_base_runcard(args.base_runcard.absolute())
+    loaded_runcard = update_paths(loaded_runcard, args.destination.absolute().parent)
+    dump_runcard(loaded_runcard, args.base_runcard.stem, args.destination.absolute())


### PR DESCRIPTION
This PR updates the default runcards and restores the update_runcards_path.py script that the documentation refers to (was absent before)