### PR TITLE
Fix central value L0 tZ_ptT

### DIFF
--- a/commondata_projections_L0/CMS_tZ_13TeV_pTt.yaml
+++ b/commondata_projections_L0/CMS_tZ_13TeV_pTt.yaml
@@ -1,7 +1,7 @@
 dataset_name: CMS_tZ_13TeV_pTt
 doi: 10.17182/hepdata.105865.v1/t42
 location: Fig. 15 top left
-arxiv: 2111.02860
+arxiv: 2111.0286
 hepdata:
   - https://www.hepdata.net/record/ins1961177?version=1&table=parton_abs_TopPt
   - https://www.hepdata.net/record/ins1961177?version=1&table=parton_abs_TopPt_covariance_stat
@@ -12,9 +12,9 @@ luminosity: 138
 num_data: 3
 num_sys: 3
 data_central:
-  - 5.497199999999999
-  - 6.102
-  - 2.92113
+  - 5.754303021818944
+  - 4.998915097641211
+  - 2.3605865472107515
 statistical_error:
   - 0.0
   - 0.0

--- a/commondata_projections_L0/CMS_tZ_13TeV_pTt.yaml
+++ b/commondata_projections_L0/CMS_tZ_13TeV_pTt.yaml
@@ -1,7 +1,7 @@
 dataset_name: CMS_tZ_13TeV_pTt
 doi: 10.17182/hepdata.105865.v1/t42
 location: Fig. 15 top left
-arxiv: 2111.0286
+arxiv: 2111.02860
 hepdata:
   - https://www.hepdata.net/record/ins1961177?version=1&table=parton_abs_TopPt
   - https://www.hepdata.net/record/ins1961177?version=1&table=parton_abs_TopPt_covariance_stat


### PR DESCRIPTION
This PR fixes a bug introduced in #75 , where the central values for the L0 version of the dataset was set equal to the real data instead of being equal to the theory best_sm.