### PR TITLE
fixing uncertainty alphaew at fcc-ee and lep3

### DIFF
--- a/commondata_projections_L0/FCCee_alphaEW.yaml
+++ b/commondata_projections_L0/FCCee_alphaEW.yaml
@@ -9,7 +9,7 @@ num_data: 1
 num_sys: 1
 data_central: 0.007799703611262771
 statistical_error:
-  - 2.34535e-06
+  - 4.81098e-08
 systematics:
   - 0.0
 sys_names: UNCORR

--- a/commondata_projections_L0/LEP3_alphaEW.yaml
+++ b/commondata_projections_L0/LEP3_alphaEW.yaml
@@ -9,7 +9,7 @@ num_data: 1
 num_sys: 1
 data_central: 0.007799703611262771
 statistical_error:
-  - 4.846899046496335e-06
+  - 9.94237e-08
 systematics:
   - 0.0
 sys_names: UNCORR


### PR DESCRIPTION
This PR introduces a fix for alphaew at fcc-ee and lep3. Before we were off by a factor 10 and took the uncertainty from off peak measurements. Now we take the on peak projection, which is more precise (3.9 versus 0.8, see table 4 in https://repository.cern/records/n2emg-43f06).

LEP3 has been rescaled as well.