### PR TITLE
Fixed null in sys types and sys names

### DIFF
--- a/Kappa_framework/ESPPU25/experiments/CEPC_240.yaml
+++ b/Kappa_framework/ESPPU25/experiments/CEPC_240.yaml
@@ -43,5 +43,5 @@ systematics:
   - 0.0
   - 0.0
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/CEPC_240_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/CEPC_240_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.00032637668288410985
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/CEPC_360.yaml
+++ b/Kappa_framework/ESPPU25/experiments/CEPC_360.yaml
@@ -79,5 +79,5 @@ systematics:
   - 0.00
   - 0.00
   - 0.00
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/FCC_ee240_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/FCC_ee240_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.000275
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/FCC_ee365_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/FCC_ee365_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.0008
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/FCC_hh84_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/FCC_hh84_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.00013
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/HL_LHC_SMTHcorr_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/HL_LHC_SMTHcorr_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.0125
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LCF_1000.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LCF_1000.yaml
@@ -34,5 +34,5 @@ systematics:
   - 0.0
   - 0.0
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LCF_250.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LCF_250.yaml
@@ -37,5 +37,5 @@ systematics:
   - 0.0
   - 0.0
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LCF_250_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LCF_250_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.0019
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LCF_350.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LCF_350.yaml
@@ -49,5 +49,5 @@ systematics:
   - 0.0
   - 0.0
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LCF_350_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LCF_350_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.012
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LCF_500.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LCF_500.yaml
@@ -58,5 +58,5 @@ systematics:
   - 0.0
   - 0.0
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LCF_500_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LCF_500_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.0042
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LEP3_240_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LEP3_240_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.0006325
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LHeC.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LHeC.yaml
@@ -52,5 +52,5 @@ systematics:
   - 0.00
   - 0.00
   - 0.00
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/LHeC_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/LHeC_invisible.yaml
@@ -11,5 +11,5 @@ data_central: 0.0
 statistical_error: 0.0275
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/muC10000.yaml
+++ b/Kappa_framework/ESPPU25/experiments/muC10000.yaml
@@ -61,5 +61,5 @@ systematics:
   - 0.00
   - 0.00
   - 0.00
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/muC10000_invisible.yaml
+++ b/Kappa_framework/ESPPU25/experiments/muC10000_invisible.yaml
@@ -9,5 +9,5 @@ data_central: 0.0
 statistical_error: 0.0013
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/Kappa_framework/ESPPU25/experiments/muC3000.yaml
+++ b/Kappa_framework/ESPPU25/experiments/muC3000.yaml
@@ -58,5 +58,5 @@ systematics:
   - 0.00
   - 0.00
   - 0.00
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_bb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_bb_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00029082
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_bb_Afb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_bb_Afb_365GeV.yaml
@@ -8,5 +8,5 @@ statistical_error:
   - 0.00242952
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_cc_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_cc_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00017493
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_cc_Afb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_cc_Afb_365GeV.yaml
@@ -8,5 +8,5 @@ statistical_error:
   - 0.00405362
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_ee_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_ee_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00467704
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_ee_Afb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_ee_Afb_365GeV.yaml
@@ -8,5 +8,5 @@ statistical_error:
   - 4.83215e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_mumu_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_mumu_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.000819806
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_mumu_Afb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_mumu_Afb_365GeV.yaml
@@ -8,5 +8,5 @@ statistical_error:
   - 0.000970445
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_tautau_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_tautau_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.000756049
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_tautau_Afb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_tautau_Afb_365GeV.yaml
@@ -8,5 +8,5 @@ statistical_error:
   - 0.00106154
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_WW_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_WW_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.000219963
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_ZZ_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_ZZ_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.000150902
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_aa_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_aa_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 1.27088e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_bb_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_bb_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 5.7211562674897315e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_bb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_bb_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.000226082
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_cc_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_cc_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.000490427
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_gg_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_gg_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 6.83578e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_vvh_tautau_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_vvh_tautau_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 8.42454e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00048635986676534066
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.0016954000000000001
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_WW_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_WW_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00014254526350677312
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_WW_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_WW_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00048752243664512164
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_ZZ_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_ZZ_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00016120933566622373
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_ZZ_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_ZZ_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.0005005456552808462
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_aZ_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_aZ_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 2.1998857121592846e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_aa_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_aa_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 1.2905427092259876e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_aa_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_aa_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 3.043103012432422e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_bb_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_bb_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00015480356865487472
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_bb_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_bb_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.0006442523999999999
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_cc_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_cc_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.0003331076782429753
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_cc_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_cc_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.0009394524185116453
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_gg_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_gg_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 6.61973412256622e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_gg_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_gg_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00017988453975134936
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_mumu_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_mumu_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 2.48135e-06
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_mumu_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_mumu_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 1.38533e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_tautau_240GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_tautau_240GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 4.532370119936436e-05
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD

--- a/commondata_projections_L0/CEPC_zh_tautau_365GeV.yaml
+++ b/commondata_projections_L0/CEPC_zh_tautau_365GeV.yaml
@@ -9,5 +9,5 @@ statistical_error:
   - 0.00014670878198673907
 systematics:
   - 0.0
-sys_names: null
-sys_type: null
+sys_names: UNCORR
+sys_type: ADD


### PR DESCRIPTION
Fixed null in CEPC and Kappa framework datasets. This was interpreted as a special systematics and it was creating inter dataset correlations.