### PR TITLE
Changing single lumi arrays to scalar

### DIFF
--- a/commondata_projections_L0/LCF_Wwidth_250GeV.yaml
+++ b/commondata_projections_L0/LCF_Wwidth_250GeV.yaml
@@ -1,8 +1,7 @@
 dataset_name: LCF_Wwidth_250GeV
 description: W total width.
 units: GeV
-luminosity:
-  - 270000
+luminosity: 270000
 num_data: 1
 num_sys: 1
 data_central: 2.045612800402105

--- a/commondata_projections_L0/LCF_Zdata_250GeV.yaml
+++ b/commondata_projections_L0/LCF_Zdata_250GeV.yaml
@@ -1,8 +1,7 @@
 dataset_name: LCF_Zdata_250GeV
 units: pb/GeV
 description: EWPOs
-luminosity:
-  - 270000
+luminosity: 270000
 num_data: 11
 num_sys: 11
 data_central:

--- a/commondata_projections_L0/LCF_alphaEW_250GeV.yaml
+++ b/commondata_projections_L0/LCF_alphaEW_250GeV.yaml
@@ -1,7 +1,6 @@
 dataset_name: LCF_alphaEW_250GeV
 description: Alpha EW.
-luminosity:
-  - 270000
+luminosity: 270000
 num_data: 1
 num_sys: 1
 data_central: 0.007799703611262771


### PR DESCRIPTION
changed luminosity to scalar when there is only one value