### PR TITLE
Sorting out the luminosities

### DIFF
--- a/commondata_projections_L0/FCCee_Wwidth.yaml
+++ b/commondata_projections_L0/FCCee_Wwidth.yaml
@@ -1,9 +1,9 @@
 dataset_name: FCCee_Wwidth
-description: W total width.
+description: W total width. Combines data from the WW threshold and higher energy runs.
 location: Table 6
 arxiv: https://repository.cern/records/n2emg-43f06
 units: GeV
-luminosity: 205000
+luminosity: 30000
 num_data: 1
 num_sys: 1
 data_central: 2.045612800402105

--- a/commondata_projections_L0/FCCee_Wwidth.yaml
+++ b/commondata_projections_L0/FCCee_Wwidth.yaml
@@ -3,7 +3,7 @@ description: W total width. Combines data from the WW threshold and higher energ
 location: Table 6
 arxiv: https://repository.cern/records/n2emg-43f06
 units: GeV
-luminosity: 30000
+luminosity: 19200
 num_data: 1
 num_sys: 1
 data_central: 2.045612800402105

--- a/commondata_projections_L0/FCCee_Wwidth.yaml
+++ b/commondata_projections_L0/FCCee_Wwidth.yaml
@@ -1,5 +1,5 @@
 dataset_name: FCCee_Wwidth
-description: W total width. Combines data from the WW threshold and higher energy runs.
+description: W total width from the WW threshold run.
 location: Table 6
 arxiv: https://repository.cern/records/n2emg-43f06
 units: GeV

--- a/commondata_projections_L0/LCF_Brw_250GeV.yaml
+++ b/commondata_projections_L0/LCF_Brw_250GeV.yaml
@@ -1,12 +1,12 @@
 dataset_name: LCF_Brw_250GeV
 description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311, rescaled by luminosity from 2503.19983.
 luminosity:
-  - 1350
-  - 1350
-  - 1350
-  - 1350
-  - 1350
-  - 1350
+  - 1500
+  - 1500
+  - 1500
+  - 1500
+  - 1500
+  - 1500
 num_data: 6
 num_sys: 6
 data_central:

--- a/commondata_projections_L0/LCF_Brw_250GeV.yaml
+++ b/commondata_projections_L0/LCF_Brw_250GeV.yaml
@@ -1,5 +1,5 @@
 dataset_name: LCF_Brw_250GeV
-description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311, rescaled by luminosity from 2503.19983.
+description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311 Table 6, rescaled by luminosity from 2503.19983 Table 3.
 luminosity:
   - 1500
   - 1500

--- a/commondata_projections_L0/LCF_Brw_250GeV.yaml
+++ b/commondata_projections_L0/LCF_Brw_250GeV.yaml
@@ -1,12 +1,12 @@
 dataset_name: LCF_Brw_250GeV
-description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311 Table 6, rescaled by luminosity from 2503.19983 Table 3.
+description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311 Table 6, rescaled by luminosity from 2503.19983 Table 3 (45% of total luminosity for +- and -+ each ).
 luminosity:
-  - 1500
-  - 1500
-  - 1500
-  - 1500
-  - 1500
-  - 1500
+  - 1350
+  - 1350
+  - 1350
+  - 1350
+  - 1350
+  - 1350
 num_data: 6
 num_sys: 6
 data_central:

--- a/commondata_projections_L0/LCF_Brw_350GeV.yaml
+++ b/commondata_projections_L0/LCF_Brw_350GeV.yaml
@@ -1,12 +1,12 @@
 dataset_name: LCF_Brw_350GeV
 description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311, rescaled by luminosity from 2503.19983.
 luminosity:
-  - 135
-  - 135
-  - 135
-  - 45
-  - 45
-  - 45
+  - 100
+  - 100
+  - 100
+  - 100
+  - 100
+  - 100
 num_data: 6
 num_sys: 6
 data_central:

--- a/commondata_projections_L0/LCF_Brw_350GeV.yaml
+++ b/commondata_projections_L0/LCF_Brw_350GeV.yaml
@@ -1,12 +1,12 @@
 dataset_name: LCF_Brw_350GeV
-description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311, rescaled by luminosity from 2503.19983.
+description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311 Table 6, rescaled by luminosity from 2503.19983v2 Table 3 (68% and 22% of total luminosity for the two polarisations each).
 luminosity:
-  - 100
-  - 100
-  - 100
-  - 100
-  - 100
-  - 100
+  - 135
+  - 135
+  - 135
+  - 45
+  - 45
+  - 45
 num_data: 6
 num_sys: 6
 data_central:

--- a/commondata_projections_L0/LCF_Brw_500GeV_4ab.yaml
+++ b/commondata_projections_L0/LCF_Brw_500GeV_4ab.yaml
@@ -1,12 +1,12 @@
 dataset_name: LCF_Brw_500GeV_4ab
 description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311, rescaled by luminosity from 2503.19983.
 luminosity:
-  - 1600.0
-  - 1600.0
-  - 1600.0
-  - 1600.0
-  - 1600.0
-  - 1600.0
+  - 4000.0
+  - 4000.0
+  - 4000.0
+  - 4000.0
+  - 4000.0
+  - 4000.0
 num_data: 6
 num_sys: 6
 data_central:

--- a/commondata_projections_L0/LCF_Brw_500GeV_4ab.yaml
+++ b/commondata_projections_L0/LCF_Brw_500GeV_4ab.yaml
@@ -1,12 +1,12 @@
 dataset_name: LCF_Brw_500GeV_4ab
 description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311 Table 6, rescaled by luminosity from 2503.19983 Table 3 (40% of total luminosity for each polarisation).
 luminosity:
-  - 1600
-  - 1600
-  - 1600
-  - 1600
-  - 1600
-  - 1600
+  - 1600.0
+  - 1600.0
+  - 1600.0
+  - 1600.0
+  - 1600.0
+  - 1600.0
 num_data: 6
 num_sys: 6
 data_central:

--- a/commondata_projections_L0/LCF_Brw_500GeV_4ab.yaml
+++ b/commondata_projections_L0/LCF_Brw_500GeV_4ab.yaml
@@ -1,12 +1,12 @@
 dataset_name: LCF_Brw_500GeV_4ab
-description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311, rescaled by luminosity from 2503.19983.
+description: W leptonic branching ratio (first, second and third generation for first polarization and then same for second polarization). Projection from 1907.04311 Table 6, rescaled by luminosity from 2503.19983 Table 3 (40% of total luminosity for each polarisation).
 luminosity:
-  - 4000.0
-  - 4000.0
-  - 4000.0
-  - 4000.0
-  - 4000.0
-  - 4000.0
+  - 1600
+  - 1600
+  - 1600
+  - 1600
+  - 1600
+  - 1600
 num_data: 6
 num_sys: 6
 data_central:

--- a/commondata_projections_L0/LCF_Wwidth_250GeV.yaml
+++ b/commondata_projections_L0/LCF_Wwidth_250GeV.yaml
@@ -1,7 +1,7 @@
 dataset_name: LCF_Wwidth_250GeV
 description: W total width.
 units: GeV
-luminosity: 270000
+luminosity: 3000
 num_data: 1
 num_sys: 1
 data_central: 2.045612800402105

--- a/commondata_projections_L0/LCF_Wwidth_250GeV.yaml
+++ b/commondata_projections_L0/LCF_Wwidth_250GeV.yaml
@@ -1,5 +1,5 @@
 dataset_name: LCF_Wwidth_250GeV
-description: W total width.
+description: W total width, from Table 3 2206.08326 rescaled to the luminosity of Table 3 in 2503.19983
 units: GeV
 luminosity: 3000
 num_data: 1

--- a/commondata_projections_L0/LEP3_Wwidth.yaml
+++ b/commondata_projections_L0/LEP3_Wwidth.yaml
@@ -1,9 +1,9 @@
 dataset_name: LEP3_Wwidth
 description: "W total width, rescaled from FCCee by the luminosities reported in https://indico.cern.ch/event/1439855/contributions/6461601/attachments/3076522/5444412/188-LEP3_update_submitted.pdf"
-location: Table 6
+location: Table 6, uses data from the WW threshold run and above
 arxiv: https://repository.cern/records/n2emg-43f06
 units: GeV
-luminosity: 48000.0
+luminosity: 7904
 num_data: 1
 num_sys: 1
 data_central: 2.045612800402105

--- a/commondata_projections_L0/LEP3_Wwidth.yaml
+++ b/commondata_projections_L0/LEP3_Wwidth.yaml
@@ -1,14 +1,14 @@
 dataset_name: LEP3_Wwidth
 description: "W total width, rescaled from FCCee by the luminosities reported in https://indico.cern.ch/event/1439855/contributions/6461601/attachments/3076522/5444412/188-LEP3_update_submitted.pdf"
-location: Table 6, uses data from the WW threshold run and above
+location: Table 6, uses data from the WW threshold run
 arxiv: https://repository.cern/records/n2emg-43f06
 units: GeV
-luminosity: 7904
+luminosity: 5600
 num_data: 1
 num_sys: 1
 data_central: 2.045612800402105
 statistical_error:
-  - 0.000526018
+  - 0.000499943
 systematics:
   - 0.0002
 sys_names: UNCORR

--- a/commondata_projections_L0/LEP3_Wwidth.yaml
+++ b/commondata_projections_L0/LEP3_Wwidth.yaml
@@ -8,7 +8,7 @@ num_data: 1
 num_sys: 1
 data_central: 2.045612800402105
 statistical_error:
-  - 0.0005579818545436761
+  - 0.000526018
 systematics:
   - 0.0002
 sys_names: UNCORR


### PR DESCRIPTION
The luminosities in the Wwidth and BrW datasets were outdated, and some comments implied that measurements were made at the Z pole when it is not the case. I tried to make it more consistent for the future, in particular if we decide to use the luminosities to rescale