### PR TITLE
updated UV cards with extra 2l2q operators

### DIFF
--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00010957363037505663
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.003694965815803593
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.60927988715671e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0025659484831969397
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.590491345666154e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0018851866407161187
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.2802199365256496e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0014433460217982783
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.454755430174121e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.3819021720696486e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0011404215480875287
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -6.848351898441039e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.7393407593764157e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0009237414539508982
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.1319589914778577e-05
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.2639179829557154e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0007634226892156184
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.755799929472944e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.9023199717891775e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0006414871207992349
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.052279229846769e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.104558459693538e-06
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.6209116919387075e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0005465925763023066
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.3976228364165385e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00047129666017902967
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0006848351898441039
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0013696703796882079
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0027393407593764157
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.09237414539508981
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.043711954862684e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.087423909725368e-06
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.2174847819450737e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00041055175731151037
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3375687301642655e-06
+          - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.675137460328531e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.0700549841314124e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0003608365054495696
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.184835968588415e-06
+          - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.36967193717683e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.73934387435366e-06
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 9.47868774870732e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00031963372109027624
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.0568444287717652e-06
+          - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 8.454755430174121e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00028510538702188217
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.485251936898947e-07
+          - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.7941007747595788e-06
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.5882015495191576e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00025588405926617677
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0003043711954862684
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0006087423909725368
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0012174847819450736
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.041055175731151035
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-07
+          - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.848351898441039e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00023093536348772455
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.764571313425215e-07
+          - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.552914262685043e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.105828525370086e-06
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.211657050740172e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00020946518230179097
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.074743696736611e-07
+          - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.6597949573892885e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001908556723039046
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.472922399282646e-07
+          - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.5891689597130585e-06
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.178337919426117e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001746203126561244
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.94474991184118e-07
+          - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.188949982368236e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.755799929472944e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00016037178019980873
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00017120879746102598
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0006848351898441039
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.023093536348772453
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.478681518752831e-07
+          - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1914726075011326e-06
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.382945215002265e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001477986326321437
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.065349037308461e-07
+          - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.052279229846769e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00013664814407557665
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.6970863500967345e-07
+          - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -9.394172700193469e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.8788345400386938e-06
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.7576690800773876e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00012671350534305874
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.367571363801683e-07
+          - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.735142727603366e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.4940570910413462e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00011782416504475742
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.071552852818691e-07
+          - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.143105705637382e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6286211411274764e-06
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.257242282254953e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010983846063625424
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00010957363037505663
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00021914726075011325
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0004382945215002265
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.014779863263214371
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-07
+          - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.043711954862684e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0003043711954862684
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.590491345666154e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00011180982691332308
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00022361965382664616
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.007540746562864475
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00017120879746102598
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.005773384087193113
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/FCCee_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.763804344139297e-05
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00013527608688278594
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.004561686192350115
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00010957363037505663
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.003694965815803593
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.60927988715671e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0025659484831969397
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.590491345666154e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0018851866407161187
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.2802199365256496e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0014433460217982783
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.454755430174121e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.3819021720696486e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0011404215480875287
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -6.848351898441039e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.7393407593764157e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0009237414539508982
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.1319589914778577e-05
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.2639179829557154e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0007634226892156184
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.755799929472944e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.9023199717891775e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0006414871207992349
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.052279229846769e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.104558459693538e-06
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.6209116919387075e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0005465925763023066
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.3976228364165385e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00047129666017902967
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0006848351898441039
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0013696703796882079
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0027393407593764157
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.09237414539508981
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.043711954862684e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.087423909725368e-06
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.2174847819450737e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00041055175731151037
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3375687301642655e-06
+          - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.675137460328531e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.0700549841314124e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0003608365054495696
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.184835968588415e-06
+          - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.36967193717683e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.73934387435366e-06
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 9.47868774870732e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00031963372109027624
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.0568444287717652e-06
+          - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 8.454755430174121e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00028510538702188217
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.485251936898947e-07
+          - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.7941007747595788e-06
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.5882015495191576e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00025588405926617677
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0003043711954862684
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0006087423909725368
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0012174847819450736
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.041055175731151035
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-07
+          - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.848351898441039e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00023093536348772455
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.764571313425215e-07
+          - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.552914262685043e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.105828525370086e-06
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.211657050740172e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00020946518230179097
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.074743696736611e-07
+          - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.6597949573892885e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001908556723039046
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.472922399282646e-07
+          - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.5891689597130585e-06
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.178337919426117e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001746203126561244
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.94474991184118e-07
+          - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.188949982368236e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.755799929472944e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00016037178019980873
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00017120879746102598
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0006848351898441039
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.023093536348772453
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.478681518752831e-07
+          - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1914726075011326e-06
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.382945215002265e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001477986326321437
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.065349037308461e-07
+          - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.052279229846769e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00013664814407557665
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.6970863500967345e-07
+          - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -9.394172700193469e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.8788345400386938e-06
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.7576690800773876e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00012671350534305874
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.367571363801683e-07
+          - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.735142727603366e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.4940570910413462e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00011782416504475742
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.071552852818691e-07
+          - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.143105705637382e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6286211411274764e-06
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.257242282254953e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010983846063625424
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00010957363037505663
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00021914726075011325
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0004382945215002265
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.014779863263214371
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-07
+          - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.043711954862684e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0003043711954862684
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.590491345666154e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00011180982691332308
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00022361965382664616
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.007540746562864475
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00017120879746102598
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.005773384087193113
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/HLLHC_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.763804344139297e-05
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00013527608688278594
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.004561686192350115
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00010957363037505663
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.003694965815803593
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.60927988715671e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0025659484831969397
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.590491345666154e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0018851866407161187
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.2802199365256496e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0014433460217982783
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.454755430174121e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.3819021720696486e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0011404215480875287
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -6.848351898441039e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.7393407593764157e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0009237414539508982
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.1319589914778577e-05
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.2639179829557154e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0007634226892156184
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.755799929472944e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.9023199717891775e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0006414871207992349
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.052279229846769e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.104558459693538e-06
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.6209116919387075e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0005465925763023066
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.3976228364165385e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00047129666017902967
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0006848351898441039
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0013696703796882079
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0027393407593764157
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.09237414539508981
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.043711954862684e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.087423909725368e-06
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.2174847819450737e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00041055175731151037
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3375687301642655e-06
+          - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.675137460328531e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.0700549841314124e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0003608365054495696
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.184835968588415e-06
+          - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.36967193717683e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.73934387435366e-06
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 9.47868774870732e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00031963372109027624
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.0568444287717652e-06
+          - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 8.454755430174121e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00028510538702188217
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.485251936898947e-07
+          - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.7941007747595788e-06
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.5882015495191576e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00025588405926617677
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0003043711954862684
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0006087423909725368
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0012174847819450736
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.041055175731151035
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-07
+          - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.848351898441039e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00023093536348772455
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.764571313425215e-07
+          - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.552914262685043e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.105828525370086e-06
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.211657050740172e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00020946518230179097
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.074743696736611e-07
+          - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.6597949573892885e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001908556723039046
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.472922399282646e-07
+          - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.5891689597130585e-06
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.178337919426117e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001746203126561244
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.94474991184118e-07
+          - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.188949982368236e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.755799929472944e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00016037178019980873
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00017120879746102598
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0006848351898441039
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.023093536348772453
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.478681518752831e-07
+          - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1914726075011326e-06
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.382945215002265e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001477986326321437
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.065349037308461e-07
+          - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.052279229846769e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00013664814407557665
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.6970863500967345e-07
+          - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -9.394172700193469e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.8788345400386938e-06
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.7576690800773876e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00012671350534305874
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.367571363801683e-07
+          - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.735142727603366e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.4940570910413462e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00011782416504475742
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.071552852818691e-07
+          - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.143105705637382e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6286211411274764e-06
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.257242282254953e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010983846063625424
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00010957363037505663
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00021914726075011325
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0004382945215002265
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.014779863263214371
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-07
+          - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.043711954862684e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0003043711954862684
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.590491345666154e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00011180982691332308
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00022361965382664616
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.007540746562864475
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00017120879746102598
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.005773384087193113
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF1000_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.763804344139297e-05
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00013527608688278594
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.004561686192350115
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00010957363037505663
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.003694965815803593
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.60927988715671e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0025659484831969397
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.590491345666154e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0018851866407161187
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.2802199365256496e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0014433460217982783
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.454755430174121e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.3819021720696486e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0011404215480875287
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -6.848351898441039e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.7393407593764157e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0009237414539508982
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.1319589914778577e-05
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.2639179829557154e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0007634226892156184
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.755799929472944e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.9023199717891775e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0006414871207992349
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.052279229846769e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.104558459693538e-06
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.6209116919387075e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0005465925763023066
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.3976228364165385e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00047129666017902967
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0006848351898441039
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0013696703796882079
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0027393407593764157
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.09237414539508981
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.043711954862684e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.087423909725368e-06
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.2174847819450737e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00041055175731151037
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3375687301642655e-06
+          - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.675137460328531e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.0700549841314124e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0003608365054495696
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.184835968588415e-06
+          - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.36967193717683e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.73934387435366e-06
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 9.47868774870732e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00031963372109027624
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.0568444287717652e-06
+          - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 8.454755430174121e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00028510538702188217
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.485251936898947e-07
+          - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.7941007747595788e-06
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.5882015495191576e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00025588405926617677
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0003043711954862684
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0006087423909725368
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0012174847819450736
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.041055175731151035
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-07
+          - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.848351898441039e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00023093536348772455
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.764571313425215e-07
+          - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.552914262685043e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.105828525370086e-06
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.211657050740172e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00020946518230179097
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.074743696736611e-07
+          - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.6597949573892885e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001908556723039046
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.472922399282646e-07
+          - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.5891689597130585e-06
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.178337919426117e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001746203126561244
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.94474991184118e-07
+          - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.188949982368236e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.755799929472944e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00016037178019980873
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00017120879746102598
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0006848351898441039
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.023093536348772453
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.478681518752831e-07
+          - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1914726075011326e-06
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.382945215002265e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001477986326321437
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.065349037308461e-07
+          - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.052279229846769e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00013664814407557665
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.6970863500967345e-07
+          - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -9.394172700193469e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.8788345400386938e-06
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.7576690800773876e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00012671350534305874
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.367571363801683e-07
+          - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.735142727603366e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.4940570910413462e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00011782416504475742
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.071552852818691e-07
+          - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.143105705637382e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6286211411274764e-06
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.257242282254953e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010983846063625424
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00010957363037505663
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00021914726075011325
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0004382945215002265
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.014779863263214371
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-07
+          - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.043711954862684e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0003043711954862684
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.590491345666154e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00011180982691332308
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00022361965382664616
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.007540746562864475
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00017120879746102598
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.005773384087193113
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LCF500_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.763804344139297e-05
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00013527608688278594
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.004561686192350115
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_10_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.4786815187528314e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0004542966584901253
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0004542966584901253
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00046799336228700735
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00010957363037505663
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.003694965815803593
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_12_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.804639943578355e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00031548379061814254
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00031548379061814254
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00032499539047708845
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.60927988715671e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0025659484831969397
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_14_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.795245672833077e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00023178400943373736
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00023178400943373736
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00023877212361582005
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.590491345666154e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0018851866407161187
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_16_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1401099682628248e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001774596322227052
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001774596322227052
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00018280990714336225
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.2802199365256496e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0014433460217982783
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_18_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.454755430174121e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6909510860348243e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0001402150180525078
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0001402150180525078
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00014444239576759485
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.3819021720696486e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0011404215480875287
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_20_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -6.848351898441039e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.3696703796882078e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.3696703796882078e-05
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.00011357416462253133
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.00011357416462253133
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.00011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.7393407593764157e-05
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0009237414539508982
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.7393407593764157e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_22_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.1319589914778577e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.1319589914778577e-05
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -9.386294596903415e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -9.386294596903415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 9.669284344772879e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 2.2639179829557154e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0007634226892156184
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 2.2639179829557154e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_24_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.755799929472944e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 9.511599858945887e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 9.511599858945887e-06
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -7.887094765453564e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -7.887094765453564e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 8.124884761927211e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.9023199717891775e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0006414871207992349
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.9023199717891775e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_26_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.052279229846769e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.104558459693538e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.104558459693538e-06
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -6.720364770563983e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -6.720364770563983e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 6.922978732056322e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.6209116919387075e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0005465925763023066
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.6209116919387075e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_28_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.9881141820826925e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.9881141820826925e-06
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.794600235843434e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.794600235843434e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.969303090395501e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.3976228364165385e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00047129666017902967
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.3976228364165385e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_2_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0006848351898441039
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0013696703796882079
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0013696703796882079
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.011357416462253132
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.011357416462253132
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.011699834057175184
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0027393407593764157
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.09237414539508981
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0027393407593764157
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_30_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.043711954862684e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.087423909725368e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.087423909725368e-06
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -5.047740649890281e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -5.047740649890281e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 5.199926247633415e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.2174847819450737e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00041055175731151037
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.2174847819450737e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_32_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.3375687301642655e-06
+          - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.675137460328531e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 5.350274920657062e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 5.350274920657062e-06
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100
@@ -681,17 +751,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -4.43649080556763e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -4.43649080556763e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.570247678584056e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.675137460328531e-06
           - -2
     max: 100
     min: -100
@@ -708,7 +820,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 1.0700549841314124e-05
@@ -743,6 +855,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -760,6 +879,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0003608365054495696
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 1.0700549841314124e-05
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_34_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.184835968588415e-06
+          - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.36967193717683e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.73934387435366e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.73934387435366e-06
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.929901890052987e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.929901890052987e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 4.048385486911828e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.36967193717683e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 9.47868774870732e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00031963372109027624
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 9.47868774870732e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_36_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.0568444287717652e-06
+          - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 4.227377715087061e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 4.227377715087061e-06
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.505375451312695e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.505375451312695e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.6110598941898714e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 2.1136888575435304e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 8.454755430174121e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00028510538702188217
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 8.454755430174121e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_38_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 9.485251936898947e-07
+          - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.7941007747595788e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.7941007747595788e-06
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -3.146098743006408e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -3.146098743006408e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 3.240951262375397e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.8970503873797894e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 7.5882015495191576e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00025588405926617677
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 7.5882015495191576e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_3_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.0003043711954862684
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0006087423909725368
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0006087423909725368
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.005047740649890281
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.005047740649890281
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.005199926247633415
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0012174847819450736
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.041055175731151035
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0012174847819450736
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_40_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-07
+          - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.4241759492205196e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.4241759492205196e-06
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.839354115563283e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.839354115563283e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.924958514293796e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.7120879746102598e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.848351898441039e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00023093536348772455
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.848351898441039e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_42_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.764571313425215e-07
+          - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.552914262685043e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 3.105828525370086e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 3.105828525370086e-06
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.5753778825970823e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.5753778825970823e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.653023595731334e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.552914262685043e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 6.211657050740172e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00020946518230179097
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 6.211657050740172e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_44_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 7.074743696736611e-07
+          - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.8298974786946443e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.8298974786946443e-06
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.3465736492258537e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.3465736492258537e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.4173210861932197e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.4149487393473221e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.6597949573892885e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001908556723039046
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.6597949573892885e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_46_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 6.472922399282646e-07
+          - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.5891689597130585e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.5891689597130585e-06
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -2.1469596336962443e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -2.1469596336962443e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.2116888576890707e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.2945844798565292e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 5.178337919426117e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001746203126561244
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 5.178337919426117e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_48_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.94474991184118e-07
+          - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.188949982368236e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.377899964736472e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.377899964736472e-06
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.971773691363391e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.971773691363391e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 2.0312211904818028e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.188949982368236e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.755799929472944e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00016037178019980873
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.755799929472944e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_4_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00017120879746102598
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00034241759492205197
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00034241759492205197
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.002839354115563283
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.002839354115563283
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.002924958514293796
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0006848351898441039
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.023093536348772453
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0006848351898441039
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_50_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.478681518752831e-07
+          - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.1914726075011326e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.1914726075011326e-06
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.817186633960501e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.817186633960501e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.8719734491480296e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0957363037505663e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.382945215002265e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.0001477986326321437
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.382945215002265e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_52_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.065349037308461e-07
+          - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 2.0261396149233844e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 2.0261396149233844e-06
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.6800911926409957e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.6800911926409957e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.7307446830140805e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 1.0130698074616922e-06
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 4.052279229846769e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00013664814407557665
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 4.052279229846769e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_54_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.6970863500967345e-07
+          - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -9.394172700193469e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.8788345400386938e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.8788345400386938e-06
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.5579446450278643e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.5579446450278643e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.6049155085288316e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 9.394172700193469e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.7576690800773876e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00012671350534305874
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.7576690800773876e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_56_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.367571363801683e-07
+          - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.735142727603366e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.7470285455206731e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.7470285455206731e-06
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.4486500589608585e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.4486500589608585e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.4923257725988753e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.735142727603366e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.4940570910413462e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00011782416504475742
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.4940570910413462e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_58_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 4.071552852818691e-07
+          - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -8.143105705637382e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.6286211411274764e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.6286211411274764e-06
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.350465691112144e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.350465691112144e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.3911812196403309e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 8.143105705637382e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.257242282254953e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010983846063625424
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.257242282254953e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_5_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 5.4786815187528314e-05
+          - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -0.00010957363037505663
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00021914726075011325
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00021914726075011325
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0018171866339605012
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0018171866339605012
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0018719734491480294
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 0.00010957363037505663
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0004382945215002265
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.014779863263214371
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0004382945215002265
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_60_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-07
+          - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-07
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 1.521855977431342e-06
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 1.521855977431342e-06
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100
@@ -678,17 +748,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -1.2619351624725702e-05
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -1.2619351624725702e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 1.2999815619083538e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-07
           - -2
     max: 100
     min: -100
@@ -705,7 +817,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 3.043711954862684e-06
@@ -740,6 +852,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -757,6 +876,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.00010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 3.043711954862684e-06
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_6_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 3.804639943578355e-05
+          - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -7.60927988715671e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.0001521855977431342
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.0001521855977431342
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0012619351624725702
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0012619351624725702
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0012999815619083538
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 7.60927988715671e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.0003043711954862684
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.010263793932787759
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.0003043711954862684
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_7_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.795245672833077e-05
+          - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -5.590491345666154e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 0.00011180982691332308
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 0.00011180982691332308
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0009271360377349495
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0009271360377349495
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0009550884944632802
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 5.590491345666154e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00022361965382664616
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.007540746562864475
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00022361965382664616
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_8_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 2.1401099682628248e-05
+          - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 8.560439873051299e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 8.560439873051299e-05
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0007098385288908207
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0007098385288908207
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.000731239628573449
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 4.2802199365256496e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00017120879746102598
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.005773384087193113
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00017120879746102598
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
+++ b/runcards/esppu_paper/uv_fits/LEP3_FutureColliders_Mod_CompositeHiggsSILH_Mass_9_Tree.yaml
@@ -189,14 +189,28 @@ coefficients:
   OQl13:
     constrain:
       - gSt:
-          - 1.6909510860348243e-05
+          - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OQl31:
+  OQl1M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQl23:
     constrain:
       - gSt:
           - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
           - -2
     max: 100
     min: -100
@@ -207,10 +221,17 @@ coefficients:
           - -2
     max: 100
     min: -100
-  OQlM1:
+  OQl3M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -311,17 +332,66 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olb:
+  Ol1b:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
           - -2
     max: 100
     min: -100
-  Old:
+  Ol1d:
     constrain:
       - gSt:
           - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol1u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - gSt:
+          - -3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - gSt:
+          - 6.763804344139297e-05
           - -2
     max: 100
     min: -100
@@ -451,10 +521,10 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Olu:
+  Omuu:
     constrain:
       - gSt:
-          - 6.763804344139297e-05
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100
@@ -684,17 +754,59 @@ coefficients:
           - -2
     max: 100
     min: -100
-  Oql31:
+  Oql13:
     constrain:
       - gSt:
           - -0.0005608600722100312
           - -2
     max: 100
     min: -100
-  OqlM1:
+  Oql1M:
     constrain:
       - gSt:
           - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - gSt:
+          - -0.0005608600722100312
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - gSt:
+          - 0.0005777695830703794
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - gSt:
+          - 3.3819021720696486e-05
           - -2
     max: 100
     min: -100
@@ -711,7 +823,7 @@ coefficients:
           - 2
     max: 100
     min: -100
-  Otat:
+  Otau:
     constrain:
       - gSt:
           - 0.00013527608688278594
@@ -746,6 +858,13 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
+          - -2
+    max: 100
+    min: -100
   Otp:
     constrain:
       - gSt:
@@ -763,6 +882,13 @@ coefficients:
     constrain:
       - gSt:
           - -0.004561686192350115
+          - -2
+    max: 100
+    min: -100
+  Otta:
+    constrain:
+      - gSt:
+          - 0.00013527608688278594
           - -2
     max: 100
     min: -100

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0003460796179989451
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.0001371162526363952
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0002007954764569148
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -0.00015345203044766543
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
@@ -625,10 +625,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.632831026009984e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - 3.269799260878696e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.899728356210842e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.00026339055234179075
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
@@ -713,10 +713,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/FCCee_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
@@ -416,10 +416,52 @@ coefficients:
           - -8
     max: 100
     min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0003460796179989451
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.0001371162526363952
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 50.0
-    min: 0.1
+    max: 7.0
+    min: 0.7
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0002007954764569148
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -0.00015345203044766543
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 50.0
-    min: 0.1
+    max: 7.0
+    min: 0.7
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 50.0
-    min: 0.1
+    max: 7.0
+    min: 0.7
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 50.0
-    min: 0.1
+    max: 7.0
+    min: 0.7
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
@@ -625,10 +625,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.632831026009984e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - 3.269799260878696e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.899728356210842e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.00026339055234179075
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 50.0
-    min: 0.1
+    max: 7.0
+    min: 0.7
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
@@ -713,10 +713,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 50.0
-    min: 0.1
+    max: 7.0
+    min: 0.7
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/HLLHC_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
@@ -416,10 +416,52 @@ coefficients:
           - -8
     max: 100
     min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 50.0
-    min: 0.1
+    max: 7.0
+    min: 0.7
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0003460796179989451
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.0001371162526363952
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0002007954764569148
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -0.00015345203044766543
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
@@ -625,10 +625,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.632831026009984e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - 3.269799260878696e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.899728356210842e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.00026339055234179075
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
@@ -713,10 +713,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF1000_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
@@ -416,10 +416,52 @@ coefficients:
           - -8
     max: 100
     min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0003460796179989451
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.0001371162526363952
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0002007954764569148
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -0.00015345203044766543
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
@@ -625,10 +625,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.632831026009984e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - 3.269799260878696e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.899728356210842e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.00026339055234179075
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
@@ -713,10 +713,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LCF500_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
@@ -416,10 +416,52 @@ coefficients:
           - -8
     max: 100
     min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004626116953642816
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0003460796179989451
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 9.251774937990627e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 4.625887468995314e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.0001371162526363952
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
@@ -665,10 +665,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.401419950392502e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -0.00046029875162978396
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 0.0004695505265677746
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -0.0002775214916807475
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 0.0002007954764569148
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.700709975196251e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.8503549875981254e-05
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -0.00015345203044766543
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Theta_4_12_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.312943734497657e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 4.82369045949147e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Theta_4_32_UVcoup_1_1Loop.yaml
@@ -555,10 +555,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 2.0816493610478912e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -4.794778662810249e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 5.054984832941236e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 1.0408246805239456e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 5.204123402619728e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
@@ -625,10 +625,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 1.1564718672488284e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 7.632831026009984e-05
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -4.794778662810249e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 4.939337646216352e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - 3.269799260878696e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.899728356210842e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 5.782359336244142e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 2.891179668122071e-07
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 0.00026339055234179075
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Xi1_UVcoup_1_1Loop.yaml
@@ -713,10 +713,164 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Omuu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Otau:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Omud:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otad:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Omub:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otab:
+    constrain:
+      - m:
+          - -3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Otmu:
+    constrain:
+      - m:
+          - 6.938831203492971e-06
+          - -2
+    max: 100
+    min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.9179114651240996e-05
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 2.0046468551677618e-05
+          - -2
+    max: 100
+    min: -100
+  Ol2u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3u:
+    constrain:
+      - m:
+          - 3.4694156017464854e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3d:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol2b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Ol3b:
+    constrain:
+      - m:
+          - -1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  Oqta:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - 1.7347078008732427e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/1LoopMatching/LEP3_MassScan_1LoopMatching_Mod_Xi_UVcoup_1_1Loop.yaml
@@ -416,10 +416,52 @@ coefficients:
           - -8
     max: 100
     min: -100
+  Oql23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql33:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  Oql3M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 9.589557325620498e-06
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 120.0
-    min: 0.1
+    max: 25.0
+    min: 2.0
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/FCCee_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/FCCee_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
@@ -303,10 +303,31 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 148.54548494983277
+    min: 70.31070234113712
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/FCCee_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/FCCee_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
@@ -177,10 +177,24 @@ coefficients:
           - -2
     max: 100
     min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 77.33177257525082
+    min: 35.20535117056856
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/HLLHC_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/HLLHC_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
@@ -303,10 +303,31 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 16.148160535117057
+    min: 7.121070234113711
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/HLLHC_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/HLLHC_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
@@ -177,10 +177,24 @@ coefficients:
           - -2
     max: 100
     min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 300
-    min: 0.1
+    max: 8.124080267558528
+    min: 3.109030100334448
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/LCF1000_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/LCF1000_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
@@ -303,10 +303,31 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 200.0
-    min: 0.1
+    max: 251.48297141370549
+    min: 123.11538461538461
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/LCF1000_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/LCF1000_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
@@ -177,10 +177,24 @@ coefficients:
           - -2
     max: 100
     min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 200.0
-    min: 0.1
+    max: 96.37290969899665
+    min: 45.562207357859535
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/LCF500_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/LCF500_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
@@ -303,10 +303,31 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 200.0
-    min: 0.1
+    max: 162.56053511705687
+    min: 76.98461538461538
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/LCF500_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/LCF500_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
@@ -177,10 +177,24 @@ coefficients:
           - -2
     max: 100
     min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 200.0
-    min: 0.1
+    max: 64.9505016722408
+    min: 30.185284280936457
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/LEP3_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/LEP3_MassScan_Granada_Mod_21_UVcoup_1_Tree.yaml
@@ -303,10 +303,31 @@ coefficients:
           - -2
     max: 100
     min: -100
+  Otmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQmu:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 200.0
-    min: 0.1
+    max: 93.69866220735786
+    min: 44.22508361204014
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006

--- a/runcards/esppu_paper/uv_mass_scans/Granada/LEP3_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
+++ b/runcards/esppu_paper/uv_mass_scans/Granada/LEP3_MassScan_Granada_Mod_23_UVcoup_1_Tree.yaml
@@ -177,10 +177,24 @@ coefficients:
           - -2
     max: 100
     min: -100
+  OQl23:
+    constrain:
+      - m:
+          - -1.0
+          - -2
+    max: 100
+    min: -100
+  OQl2M:
+    constrain:
+      - m:
+          - 1.0
+          - -2
+    max: 100
+    min: -100
   m:
     is_mass: true
-    max: 200.0
-    min: 0.1
+    max: 56.92775919732442
+    min: 26.173913043478265
 data_path: /data/theorie/arossia/smefit_database/commondata_projections_L0
 datasets:
   - name: LEP1_EWPOs_2006


### PR DESCRIPTION
Updated cards for CHM, 1-loop matched and Z' and W' models with additional 2-lepton-2-quark operators.